### PR TITLE
Updated data source reference to use .id ATTR

### DIFF
--- a/website/docs/d/team.html.markdown
+++ b/website/docs/d/team.html.markdown
@@ -25,7 +25,7 @@ resource "pagerduty_escalation_policy" "foo" {
   name      = "DevOps Escalation Policy"
   num_loops = 2
 
-  teams = ["${data.pagerduty_team.devops}"]
+  teams = ["${data.pagerduty_team.devops.id}"]
 
   rule {
     escalation_delay_in_minutes = 10


### PR DESCRIPTION
fails with error otherwise:
```go
data.pagerduty_team.team: data variables must be four parts: data.TYPE.NAME.ATTR in:

${data.pagerduty_team.devops}
```